### PR TITLE
remove possible '//' to '/' on TMPDIR

### DIFF
--- a/find-unused-function.sh
+++ b/find-unused-function.sh
@@ -28,6 +28,8 @@
     fi
 
     TMPDIR="${2}/DebugSymbol"
+    # replace possible '//' with '/'
+    TMPDIR=${TMPDIR//\/\//\/}
 
     if [[ ! -d "${TMPDIR}" ]] ;
     then


### PR DESCRIPTION
when the path/object-dir/*.o provide with ./ similar, TMPDIR will include '//'